### PR TITLE
ptdump: Fix libipt linker flag.

### DIFF
--- a/ptdump/CMakeLists.txt
+++ b/ptdump/CMakeLists.txt
@@ -48,4 +48,4 @@ add_executable(ptdump
   ${PTDUMP_FILES}
 )
 
-target_link_libraries(ptdump libipt)
+target_link_libraries(ptdump ipt)


### PR DESCRIPTION
The build was invoking the compiler with `-llibipt` but it should using `-lipt`:

```
[100%] Linking C executable ptdump
/usr/bin/cmake -E cmake_link_script CMakeFiles/ptdump.dir/link.txt --verbose=1
/usr/bin/cc  -I/home/vext01/research/hwt_experiment/deps/inst/libipt/include  -L/home/vext01/research/hwt_experiment/deps/inst/libipt/lib -Wl,-rpath,/home/vext01/research/hwt_experiment/deps/inst/libipt/lib CMakeFiles/ptdump.dir/src/ptdump.o CMakeFiles/ptdump.dir/home/vext01/research/hwt_experiment/deps/src/processor-trace/libipt/src/pt_last_ip.o CMakeFiles/ptdump.dir/home/vext01/research/hwt_experiment/deps/src/processor-trace/libipt/src/pt_cpu.o CMakeFiles/ptdump.dir/home/vext01/research/hwt_experiment/deps/src/processor-trace/libipt/src/pt_time.o CMakeFiles/ptdump.dir/home/vext01/research/hwt_experiment/deps/src/processor-trace/libipt/src/posix/pt_cpuid.o  -o ptdump -rdynamic -llibipt
/usr/bin/ld: cannot find -llibipt
```

This PR fixes this.