### PR TITLE
ptxed: print errors if loading the --raw argument binary fails.

### DIFF
--- a/ptxed/src/ptxed.c
+++ b/ptxed/src/ptxed.c
@@ -549,8 +549,11 @@ static int load_raw(struct pt_image_section_cache *iscache,
 	int isid, errcode, has_base;
 
 	has_base = extract_base(arg, &base);
-	if (has_base <= 0)
+	if (has_base <= 0) {
+		fprintf(stderr, "%s: failed to parse base address"
+			"from '%s'.\n", prog, arg);
 		return -1;
+	}
 
 	errcode = preprocess_filename(arg, &foffset, &fsize);
 	if (errcode < 0) {
@@ -2164,8 +2167,11 @@ extern int main(int argc, char *argv[])
 			arg = argv[i++];
 
 			errcode = load_raw(decoder.iscache, image, arg, prog);
-			if (errcode < 0)
+			if (errcode < 0) {
+				fprintf(stderr, "%s: --raw: failed to load "
+					"'%s'.\n", prog, arg);
 				goto err;
+			}
 
 			continue;
 		}


### PR DESCRIPTION
Hi!

I was confused why when running:
```
ptxed -v --cpu auto --pt trace.pt --raw vm
```

gave no output. It just exits.

Was there no trace information to display? Had something gone wrong?

Well, a `gdb` session reveals that loading the binary referenced by `--raw` was failing because I didn't specify a base address. i.e. I was supposed to do something like:

```
ptxed -v --cpu auto --pt trace.pt --raw vmp:0x556946d61000
```

This seems to work:
```
[enabled]
[exec mode: 64-bit]
[28, 7fb8fc4d3700: error: no memory mapped at this address]
0000556946d625a8  add eax, 0x1
0000556946d625ab  mov dword ptr [rbp-0x14], eax
0000556946d625ae  mov eax, dword ptr [rbp-0x14]
...
```

This PR makes `ptxed` print an error if:
 * Loading the binary fails
 * Parsing a base address offset fails.

Looks good?

While I have you here, the offset address should be the executable section of the binary, right?

So if we have (from `/proc/<pid>/maps`)
```
556946d61000-556946d64000 r-xp 00000000 08:01 21515243                   /home/vext01/research/hardware_tracer/vm
556946f63000-556946f64000 r--p 00002000 08:01 21515243                   /home/vext01/research/hardware_tracer/vm
556946f64000-556946f65000 rw-p 00003000 08:01 21515243                   /home/vext01/research/hardware_tracer/vm
5569482a8000-5569482c9000 rw-p 00000000 00:00 0                          [heap]
7fb8fc3f8000-7fb8fc58d000 r-xp 00000000 08:01 5373963                    /lib/x86_64-linux-gnu/libc-2.24.so
7fb8fc58d000-7fb8fc78d000 ---p 00195000 08:01 5373963                    /lib/x86_64-linux-gnu/libc-2.24.so
7fb8fc78d000-7fb8fc791000 r--p 00195000 08:01 5373963                    /lib/x86_64-linux-gnu/libc-2.24.so
7fb8fc791000-7fb8fc793000 rw-p 00199000 08:01 5373963                    /lib/x86_64-linux-gnu/libc-2.24.so
7fb8fc793000-7fb8fc797000 rw-p 00000000 00:00 0
7fb8fc797000-7fb8fc7ba000 r-xp 00000000 08:01 5373956                    /lib/x86_64-linux-gnu/ld-2.24.so
7fb8fc9a1000-7fb8fc9a3000 rw-p 00000000 00:00 0
7fb8fc9b7000-7fb8fc9ba000 rw-p 00000000 00:00 0
7fb8fc9ba000-7fb8fc9bb000 r--p 00023000 08:01 5373956                    /lib/x86_64-linux-gnu/ld-2.24.so
7fb8fc9bb000-7fb8fc9bc000 rw-p 00024000 08:01 5373956                    /lib/x86_64-linux-gnu/ld-2.24.so
7fb8fc9bc000-7fb8fc9bd000 rw-p 00000000 00:00 0
7ffd9a71d000-7ffd9a73e000 rw-p 00000000 00:00 0                          [stack]
7ffd9a7ec000-7ffd9a7ee000 r--p 00000000 00:00 0                          [vvar]
7ffd9a7ee000-7ffd9a7f0000 r-xp 00000000 00:00 0                          [vdso]
ffffffffff600000-ffffffffff601000 r-xp 00000000 00:00 0                  [vsyscall]
```

I should specify `0x556946d61000` as the base address, right?

Thanks